### PR TITLE
Fix MISX versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
         id: msixver
         with:
           value: ${{ github.event.release.tag_name }}
-          regex: \-\w+
+          regex: (\-\w+)|(\+\w+)
           replacement: ""
 
       - name: Write MSIX

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,14 @@ jobs:
 
       - name: Set new Flutter version
         run: cider version ${{ github.event.release.tag_name }}
+        
+      - name: Generate MSIX-compatible version
+        uses: ashley-taylor/regex-property-action@1.2
+        id: msixver
+        with:
+          value: ${{ github.event.release.tag_name }}
+          regex: \-\w+
+          replacement: ""
 
       - name: Write MSIX
         uses: DamianReeves/write-file-action@v1.0
@@ -158,7 +166,7 @@ jobs:
               display_name: Sidekick
               publisher_display_name: Sidekick Contributors
               identity_name: app.fvm.sidekick
-              msix_version: ${{ github.event.release.tag_name }}.0
+              msix_version: ${{steps.msixver.outputs.value }}
               logo_path: .\macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_128.png
               start_menu_icon_path: .\macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_128.png
               tile_icon_path: .\macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_128.png


### PR DESCRIPTION
I've added a regex filter to the MSIX version, which should allow the build to pass and add the ability to update. This regex does have some limitations though, for example:

`1.0.0-beta.1` would not work to update from `1.0.0-alpha.5` as the versions would be `1.0.0.1` and `1.0.0.5` respectively, and would therefore appear as a downgrade to the MSIX package. 