### PR TITLE
Remove elevation and add border to info drawer

### DIFF
--- a/lib/components/organisms/info_drawer.dart
+++ b/lib/components/organisms/info_drawer.dart
@@ -32,42 +32,58 @@ class InfoDrawer extends HookWidget {
     }
 
     if (selected == null) {
-      return Drawer(
-        child: Container(
-          color: Theme.of(context).cardColor,
-          child: const Center(child: Caption('Nothing selected')),
+      return Container(
+        decoration: BoxDecoration(
+          border: Border(
+            left: BorderSide(color: Theme.of(context).dividerColor, width: 0.5),
+          ),
+        ),
+        child: Drawer(
+          elevation: 0,
+          child: Container(
+            color: Theme.of(context).cardColor,
+            child: const Center(child: Caption('Nothing selected')),
+          ),
         ),
       );
     }
 
-    return Drawer(
-      child: Scaffold(
-        backgroundColor: Theme.of(context).cardColor,
-        appBar: AppBar(
-          title: Heading(selected.name),
-          leading: IconButton(
-            icon: const Icon(Icons.close),
-            iconSize: 20,
-            splashRadius: 20,
-            onPressed: onClose,
-          ),
-          shadowColor: Colors.transparent,
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(
+          left: BorderSide(color: Theme.of(context).dividerColor, width: 0.5),
         ),
-        bottomNavigationBar: Container(
-          padding: const EdgeInsets.all(10),
-          margin: const EdgeInsets.all(0),
-          child: VersionInstallButton(
-            selected,
-            warningIcon: true,
+      ),
+      child: Drawer(
+        elevation: 0,
+        child: Scaffold(
+          backgroundColor: Theme.of(context).cardColor,
+          appBar: AppBar(
+            title: Heading(selected.name),
+            leading: IconButton(
+              icon: const Icon(Icons.close),
+              iconSize: 20,
+              splashRadius: 20,
+              onPressed: onClose,
+            ),
+            shadowColor: Colors.transparent,
           ),
-        ),
-        body: Scrollbar(
-          child: ListView(
-            children: [
-              ReferenceInfoTile(selected),
-              CacheInfoTile(selected),
-              ReleaseInfoSection(selected)
-            ],
+          bottomNavigationBar: Container(
+            padding: const EdgeInsets.all(10),
+            margin: const EdgeInsets.all(0),
+            child: VersionInstallButton(
+              selected,
+              warningIcon: true,
+            ),
+          ),
+          body: Scrollbar(
+            child: ListView(
+              children: [
+                ReferenceInfoTile(selected),
+                CacheInfoTile(selected),
+                ReleaseInfoSection(selected)
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
This PR is a small change yo the elevation in the info drawer.

In light mode the elevation becomes a little distracting (in my opinion). This PR removes the elevation and instead adds a solid border color:

@leoafarias if you think it doesn't look good feel free to close the PR 👍 

## Light Mode

![image](https://user-images.githubusercontent.com/29983481/112750811-05995500-8fcb-11eb-9a0a-1917b244f8a8.png)
![image](https://user-images.githubusercontent.com/29983481/112750828-25c91400-8fcb-11eb-9c12-65ca11f39fe4.png)

## Dark Mode

![image](https://user-images.githubusercontent.com/29983481/112751039-14ccd280-8fcc-11eb-8e85-1b965d98f45b.png)
![image](https://user-images.githubusercontent.com/29983481/112751075-49408e80-8fcc-11eb-9780-4c283617f02c.png)

