### PR TITLE
Fix issue where onInstall would run even if version was intalled

### DIFF
--- a/lib/components/molecules/version_install_button.dart
+++ b/lib/components/molecules/version_install_button.dart
@@ -88,7 +88,7 @@ class VersionInstallButton extends HookWidget {
       child: Opacity(
         opacity: version.isInstalled ? 0.3 : 1,
         child: IconButton(
-          onPressed: version.isInstalled ? onInstall : onInstall,
+          onPressed: version.isInstalled ? () {} : onInstall,
           splashRadius: 20,
           icon: Tooltip(
               message: version.isInstalled ? installedMsg : notInstalledMsg,

--- a/lib/components/molecules/version_install_button.dart
+++ b/lib/components/molecules/version_install_button.dart
@@ -88,7 +88,7 @@ class VersionInstallButton extends HookWidget {
       child: Opacity(
         opacity: version.isInstalled ? 0.3 : 1,
         child: IconButton(
-          onPressed: version.isInstalled ? () {} : onInstall,
+          onPressed: version.isInstalled ? null : onInstall,
           splashRadius: 20,
           icon: Tooltip(
               message: version.isInstalled ? installedMsg : notInstalledMsg,


### PR DESCRIPTION
Fixes a bug whereby installation of a version starts even if the version is already installed