### PR TITLE
update main.cc to support wayland gdk backend

### DIFF
--- a/linux/main.cc
+++ b/linux/main.cc
@@ -1,10 +1,6 @@
 #include "my_application.h"
 
 int main(int argc, char** argv) {
-  // Only X11 is currently supported.
-  // Wayland support is being developed: https://github.com/flutter/flutter/issues/57932.
-  gdk_set_allowed_backends("x11");
-
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }


### PR DESCRIPTION
Looks like the flutter app was made with a older version of flutter create template. The following [PR](https://github.com/flutter/flutter/pull/66519) adds support for wayland and hence the x11 lines can be removed from main.cc
