### PR TITLE
Lowercased search queries for reliable results

### DIFF
--- a/lib/providers/search_results_provider.dart
+++ b/lib/providers/search_results_provider.dart
@@ -78,7 +78,8 @@ final searchResultsProvider = Provider((ref) {
       // Get projec pinnedVersion
       final pinnedVersion = project.pinnedVersion ?? '';
       // Add project if name or pinnedVersion start with term
-      if (project.name.startsWith(term) || pinnedVersion.startsWith(term)) {
+      if (project.name.toLowerCase().startsWith(term) ||
+          pinnedVersion.startsWith(term)) {
         // Add to track unique insertions
         uniques[project.name] = true;
 

--- a/lib/providers/search_results_provider.dart
+++ b/lib/providers/search_results_provider.dart
@@ -47,7 +47,7 @@ final searchResultsProvider = Provider((ref) {
   }
 
   // Split query into multiple search terms
-  final searchTerms = query.split(' ');
+  final searchTerms = query.toLowerCase().split(' ');
 
   final projectResults = <Project>[];
   final channelResults = <ChannelDto>[];


### PR DESCRIPTION
**Issue**
Searching for projects shouldn't be bound to input type-case. Results should be the same for:

* MyProject
* myproject

Currently, typing MyProject would return a "No Flutter projects found" error.

**Solution**
Lowercase the query input to make this universal across folder names.