### PR TITLE
fix: prevent crash when closing version details sidebar

### DIFF
--- a/lib/src/components/organisms/info_drawer.dart
+++ b/lib/src/components/organisms/info_drawer.dart
@@ -19,8 +19,7 @@ class SelectedDetailDrawer extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final detail = useProvider(selectedDetailProvider).state;
-
-    final selected = detail.release;
+    final selected = detail?.release;
 
     void onClose() {
       // Close drawer if its not large layout

--- a/lib/src/modules/common/app_shell.dart
+++ b/lib/src/modules/common/app_shell.dart
@@ -48,7 +48,7 @@ class AppShell extends HookWidget {
     useValueChanged(selectedInfo, (_, __) {
       if (_scaffoldKey.currentState == null) return;
       final isOpen = _scaffoldKey.currentState.isEndDrawerOpen;
-      final hasInfo = selectedInfo.release != null;
+      final hasInfo = selectedInfo?.release != null;
 
       // Open drawer if not large layout and its not open
       if (hasInfo && !isOpen) {


### PR DESCRIPTION
Hi! 👋🏽 

When closing the version details sidebar, the app crashes because `useProvider(selectedDetailProvider).state` returns `null`.

This PR adds [conditional property access](https://dart.dev/codelabs/dart-cheatsheet#conditional-property-access) to solve the crash.

<details>
  <summary>See bug demo</summary>


https://user-images.githubusercontent.com/13774309/121434872-4247dc00-c97e-11eb-91f8-a760d2f53574.mp4



</details>