### PR TITLE
Add artifacts to main build action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,9 +84,12 @@ jobs:
       - name: Flutter build app
         run: flutter build macos
 
+      - name: Install create-dmg
+        run: brew install create-dmg
+
       - name: Create dmg
         run: |
-          scripts/create_mac_dmg.sh
+          ./scripts/create_mac_dmg.sh
 
       - name: Compress artifacts
         run: zip -r macos-${{ github.event.release.tag_name }}.zip build/macos/Build/Products/Release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -92,7 +92,7 @@ jobs:
           ./scripts/create_mac_dmg.sh
 
       - name: Compress artifacts
-        run: zip -r macos-${{ github.event.release.tag_name }}.zip build/macos/Build/Products/Release
+        run: zip -r macos-dev.zip build/macos/Build/Products/Release
 
       - name: Upload Build DMG
         uses: actions/upload-artifact@v2.3.1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Upload Build Zip
         uses: actions/upload-artifact@v2.3.1
         with:
-          name: sidekick-windows-dev.dmg
+          name: sidekick-linux-dev.zip
           path: linux-dev.zip
       
   build-macos:
@@ -86,7 +86,7 @@ jobs:
 
       - name: Create dmg
         run: |
-          ./scripts/create_mac_dmg.sh
+          scripts/create_mac_dmg.sh
 
       - name: Compress artifacts
         run: zip -r macos-${{ github.event.release.tag_name }}.zip build/macos/Build/Products/Release
@@ -100,7 +100,7 @@ jobs:
       - name: Upload Build Zip
         uses: actions/upload-artifact@v2.3.1
         with:
-          name: sidekick-macos-dev.dmg
+          name: sidekick-macos-dev.zip
           path: macos-dev.zip
 
 
@@ -174,5 +174,5 @@ jobs:
       - name: Upload Build Zip
         uses: actions/upload-artifact@v2.3.1
         with:
-          name: sidekick-windows-dev.dmg
+          name: sidekick-windows-dev.zip
           path: windows-dev.zip

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,6 +33,30 @@ jobs:
 
       - name: Flutter build app
         run: flutter build linux
+
+
+      - name: Compress artifacts
+        uses: TheDoctor0/zip-release@0.4.1
+        with:
+          filename: linux-dev.zip
+
+      - name: Build AppImage
+        uses: AppImageCrafters/build-appimage@master
+        with:
+          recipe: "AppImageBuilder.yml"
+
+      - name: Upload Build AppImage
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: sidekick-linux-dev.AppImage
+          path: Sidekick-latest-x86_64.AppImage
+      
+      - name: Upload Build Zip
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: sidekick-windows-dev.dmg
+          path: linux-dev.zip
+      
   build-macos:
     name: "Build MacOS"
     runs-on: macos-latest
@@ -60,6 +84,26 @@ jobs:
       - name: Flutter build app
         run: flutter build macos
 
+      - name: Create dmg
+        run: |
+          ./scripts/create_mac_dmg.sh
+
+      - name: Compress artifacts
+        run: zip -r macos-${{ github.event.release.tag_name }}.zip build/macos/Build/Products/Release
+
+      - name: Upload Build DMG
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: sidekick-macos-dev.dmg
+          path: build/macos/Build/Products/Release/Sidekick.dmg
+      
+      - name: Upload Build Zip
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: sidekick-macos-dev.dmg
+          path: macos-dev.zip
+
+
   build-windows:
     name: "Build Windows"
     runs-on: windows-latest
@@ -81,5 +125,54 @@ jobs:
       - name: Analyze
         run: flutter analyze
 
+      - name: Write MSIX
+        uses: DamianReeves/write-file-action@v1.0
+        with:
+          path: pubspec.yaml
+          contents: |
+            msix_config:
+              display_name: Sidekick DEV Build
+              publisher_display_name: Eduardo M.
+              identity_name: 44484EduardoM.SidekickFlutter
+              publisher: CN=1E781C91-227E-4505-B5B8-7E5EFE39D3A6
+              msix_version: 1.0.0.0
+              logo_path: .\macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_128.png
+              start_menu_icon_path: .\macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_128.png
+              tile_icon_path: .\macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_128.png
+              icons_background_color: transparent
+              architecture: x64
+              capabilities: "internetClient,removableStorage"
+              certificate_path: windows\SIDEKICK-CERT.pfx
+              certificate_password: ${{ secrets.WIN_CERT_PASS }}
+              store: false
+          write-mode: append
+
+      - name: Write MS Store 
+        uses: DamianReeves/write-file-action@v1.0
+        with:
+          path: lib/modifiers.dart
+          contents: |
+            // Generated file. Do not modify
+            const isMSStore = false;
+          write-mode: overwrite
+
       - name: Flutter build app
         run: flutter build windows
+
+      - name: Create MSIX
+        run: flutter pub run msix:create
+
+      - name: Compress artifacts
+        run: tar.exe -a -c -f windows-dev.zip build/windows/Runner/release
+
+      - name: Upload Build MSIX
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: sidekick-windows-dev.msix
+          path: build/windows/Runner/release/sidekick.msix
+      
+      - name: Upload Build Zip
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: sidekick-windows-dev.dmg
+          path: windows-dev.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
           path: lib/modifiers.dart
           contents: |
             // Generated file. Do not modify
-            const isMSStore = false;
+            const isMSStore = true;
           write-mode: overwrite
 
       - name: Flutter get packages


### PR DESCRIPTION
This PR allows the actions to upload an executable file. Possibly allowing for a "master" update channel in the future. However, for the moment, it just makes testing things like #177 much easier for people (like me) that don't have all device types and running multiple VMs to build and different ones to test is just not worth it.